### PR TITLE
Fix invalid path errors in Unit Tests under Windows due to backslash …

### DIFF
--- a/src/test/java/cloudsync/FilesystemHelper.java
+++ b/src/test/java/cloudsync/FilesystemHelper.java
@@ -1,0 +1,16 @@
+package cloudsync;
+
+public class FilesystemHelper {
+    private static String OS = System.getProperty("os.name").toLowerCase();
+
+    public static boolean isWindows() {
+        return (OS.indexOf("win") >= 0);
+    }
+
+    public static String fixPathSeparators(String path) {
+        if (isWindows()) {
+            return path.replace("\\", "\\\\");
+        }
+        return path;
+    }
+}

--- a/src/test/java/cloudsync/RemoteLocalFilesystemTest.java
+++ b/src/test/java/cloudsync/RemoteLocalFilesystemTest.java
@@ -62,12 +62,14 @@ public class RemoteLocalFilesystemTest {
         File targetLocalRemoteFolder = Files.createTempDirectory("targetRemoteFolder").toFile();
         File restoreFolder = new File(rootFolder.getParent(),rootFolder.getName()+"_restore");
         File configFile = Files.createTempFile("test1Config", ".config").toFile();
-        
+
+        String targetLocalRemoteFolderPath = FilesystemHelper.fixPathSeparators(targetLocalRemoteFolder.getAbsolutePath());
+
         String config = "REMOTE_CONNECTOR=LocalFilesystem";
         config += "\n"+ "PASSPHRASE=1234567";
-        config += "\n"+ "TARGET_DIR=" + targetLocalRemoteFolder.getAbsolutePath();
-        config += "\n"+ "CACHEFILE="+targetLocalRemoteFolder.getAbsolutePath() + File.separator + ".cloudsync_{name}.cache";
-        config += "\n"+ "LOGFILE="+targetLocalRemoteFolder.getAbsolutePath() + File.separator + ".cloudsync_{name}.log";
+        config += "\n"+ "TARGET_DIR=" + targetLocalRemoteFolderPath;
+        config += "\n"+ "CACHEFILE=" + targetLocalRemoteFolderPath + File.separator + ".cloudsync.cache";
+        config += "\n"+ "LOGFILE=" + targetLocalRemoteFolderPath + File.separator + ".cloudsync.log";
         Files.write(configFile.toPath(), config.getBytes(), StandardOpenOption.CREATE);
                 
         System.out.println("RootFolder: " + rootFolder.getAbsolutePath());
@@ -119,12 +121,14 @@ public class RemoteLocalFilesystemTest {
         System.out.println("Test2");
         System.out.println("RootFolder: " + rootFolder.getAbsolutePath());
         System.out.println("TargetFolder: " + targetLocalRemoteFolder.getAbsolutePath());
-        
+
+        String targetLocalRemoteFolderPath = FilesystemHelper.fixPathSeparators(targetLocalRemoteFolder.getAbsolutePath());
+
         String config = "REMOTE_CONNECTOR=LocalFilesystem";
         config += "\n"+ "PASSPHRASE=1234567";
-        config += "\n"+ "TARGET_DIR=" + targetLocalRemoteFolder.getAbsolutePath();
-        config += "\n"+ "CACHEFILE="+targetLocalRemoteFolder.getAbsolutePath() + File.separator + ".cloudsync_{name}.cache";
-        config += "\n"+ "LOGFILE="+targetLocalRemoteFolder.getAbsolutePath() + File.separator + ".cloudsync_{name}.log";
+        config += "\n"+ "TARGET_DIR=" + targetLocalRemoteFolderPath;
+        config += "\n"+ "CACHEFILE=" + targetLocalRemoteFolderPath + File.separator + ".cloudsync.cache";
+        config += "\n"+ "LOGFILE=" + targetLocalRemoteFolderPath + File.separator + ".cloudsync.log";
         config += "\n"+ "HISTORY=3";
         Files.write(configFile.toPath(), config.getBytes(), StandardOpenOption.CREATE);
            


### PR DESCRIPTION
…formatting

File.getAbsolutePath() returns a path with single backslashes. Add a
simple helper class that converts backslashes.

Closes #34.